### PR TITLE
Add scipy to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "matplotlib>=1.5.3",
         "numpy>=1.11.1",
         "pandas>=0.18.1",
+        "scipy"
     ],
     url='https://github.com/facebookincubator/bootstrapped',
 )


### PR DESCRIPTION
After installing bootstrapped, I get an import error when scipy is not installed