### PR TITLE
Update compare_functions.py

### DIFF
--- a/bootstrapped/compare_functions.py
+++ b/bootstrapped/compare_functions.py
@@ -30,7 +30,7 @@ def percent_change(test_stat, ctrl_stat):
     Returns:
         (test_stat - ctrl_stat) / ctrl_stat * 100
     """
-    return (test_stat - ctrl_stat) * 100.0 / ctrl_stat
+    return (test_stat - ctrl_stat) * 100.0 / abs(ctrl_stat)
 
 
 def ratio(test_stat, ctrl_stat):


### PR DESCRIPTION
When there are negative #s involved for test_stat and ctrl_stat, the percent_change compare_func is providing us percent change results in the wrong direction - providing abs(ctrl_stat) instead fixes this issue.

For example:
# (test_stat - ctrl_stat) * 100.0 / ctrl_stat
# 10% increase for two negative numbers incorrectly shows as a % decrease
(-90 - -100) * 100.0 / -100
Output: -10.0

# (test_stat - ctrl_stat) * 100.0 / ctrl_stat
# 10% decrease for two negative numbers incorrectly shows as a % increase
(-110 - -100) * 100.0 / -100
Output: 10.0

# new version: (test_stat - ctrl_stat) * 100.0 / abs(ctrl_stat)
# 10% increase for two negative numbers correctly shows as a % increase
(-90 - -100) * 100.0 / abs(-100)
Output: 10.0

# (test_stat - ctrl_stat) * 100.0 / ctrl_stat
# 10% decrease for two negative numbers correctly shows as a % decrease
(-110 - -100) * 100.0 / abs(-100)
Output: -10.0